### PR TITLE
Fix installation

### DIFF
--- a/lib/puppet/provider/package/cpanm.rb
+++ b/lib/puppet/provider/package/cpanm.rb
@@ -18,7 +18,11 @@ Puppet::Type.type(:package).provide :cpanm, :parent => Puppet::Provider::Package
     module_vers_re = %r{"VERSION: ((\d+\.?)+)}
 
     # Shell out and parse `perldoc perllocal`
-    execpipe '/usr/bin/perldoc -t perllocal' do |process|
+    #
+    # If no perl modules are installed, perldoc will exit 1 and print "No
+    # documentation found for "perllocal" to stderr. In order to cope with
+    # this eventuality, we catch errors ('|| true') and redirect stderr.
+    execpipe '/usr/bin/perldoc -t perllocal 2>/dev/null || true' do |process|
       process.collect do |line|
         case line
         when module_name_re

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,5 @@
 class cpanm::install {
-  package {
-    'cpanminus':
-      ensure => installed;
-  }
+  if ! defined(Package['cpanminus'])  { package { 'cpanminus': ensure => installed } }
+  if ! defined(Package['perl-doc'])   { package { 'perl-doc':  ensure => installed } }
 }
 


### PR DESCRIPTION
This PR fixes a couple of minor bugs related to installation of cpanm on a brand new machine. It addresses torrancew/puppet-cpanm#1 by installing perl-doc in `cpanm::install`, and it also makes sure that the `cpanm` provider doesn't break if there are no perl modules installed on the system.
